### PR TITLE
Add `continue` and `break`

### DIFF
--- a/src/Compiler/Ast.hs
+++ b/src/Compiler/Ast.hs
@@ -82,6 +82,8 @@ data Statement = While { getCond :: Expression
                | LocalVar VarDecl
                | StmtExprStmt StmtExpr
                | TypedStatement(Statement, Type)
+               | Continue
+               | Break
   deriving (Show, Eq)
 
 -- | 'StmtExpr' can be a 'Statement' as well as an 'Expression'

--- a/src/Compiler/Parser.hs
+++ b/src/Compiler/Parser.hs
@@ -23,7 +23,8 @@ mods = [(Protected,"protected"),(Public,"public"),(Private,"private"),(Static,"s
 
 kwords :: [String]
 kwords = ["if","then","else","while","do","skip"
-         ,"true","false","not","and","or","class","return"] ++ map snd mods
+         ,"true","false","not","and","or","class"
+         ,"return","continue","break"] ++ map snd mods
 
 -- | 'identifier' parses an identifier.
 
@@ -334,6 +335,8 @@ whileStmtNoShortIf = do
 
 statementWithoutTrailing :: Parser (Maybe Statement)
 statementWithoutTrailing = Just <$> block
+                       <|> try (const (Just Continue) <$> kword "continue" <* semicolon)
+                       <|> try (const (Just Break) <$> kword "break" <* semicolon)
                        <|> try emptyStmt
                        <|> try (Just <$> returnStmt)
                        <|> try (Just <$> expressionStmt)

--- a/test/Compiler/ParserSpec.hs
+++ b/test/Compiler/ParserSpec.hs
@@ -548,7 +548,7 @@ spec = do
 		  Just (Block 
 		   [While {
 			 getCond = Literal (BooleanL True), 
-			 getBody = Just (Block [])}])}]]
+			 getBody = Just (Block [Break])}])}]]
      it "some method calls on rhs and calculations with methods (method + method)" $
 	   parseTestString "class MethodCalc{void Calc(){int i = intMethod();char c = 'a';if(boolMethod())c = charMethod();boolean b;b = boolMethod();        int q = intMethod() + i;        int a = intMethod() + intMethod();}    int intMethod(){return 1;}    boolean boolMethod(){return true;}    char charMethod(){return 'Z';}    }"
 	   `shouldBe`


### PR DESCRIPTION
- Add nodes for them as `Statements`
- Add support in parser
Fixes #19 

The only issue here:
As of now `break` and `continue` can be placed anywhere. I guess that is okay for now and should not be added in the existing *Semantic Check*. If we wanted to implement a check for that, I would propose another phase for that.